### PR TITLE
factor progressiveFetch into tools.js for reuse by other pages

### DIFF
--- a/generate-wasm-examples/generate_wasm_examples.sh
+++ b/generate-wasm-examples/generate_wasm_examples.sh
@@ -37,15 +37,11 @@ add_category()
         wasm-bindgen --out-dir ../../content/examples/$category_path/$example --no-typescript --target web target/wasm32-unknown-unknown/release/examples/$example.wasm
 
         # Patch generated JS to allow to inject custom `fetch` with loading feedback.
-        # See `example.html` template for the other half of the implementation.
-        # This is a temporary workaround until Bevy has an in-engine mode for showing loading feeback. See:
-        # https://github.com/bevyengine/bevy-website/pull/355
-        # https://github.com/bevyengine/bevy-website/issues/338
-        # https://github.com/bevyengine/bevy-website/issues/236
+        # See: https://github.com/bevyengine/bevy-website/pull/355
         sed -i.bak \
-          -e 's/function init(input) {/function init(customFetch, input) { customFetch = customFetch || fetch;/' \ # Allow injecting a custom `fetch`, defaults to `fetch` if omitted
-          -e 's/input = fetch(/input = customFetch(/' \ # Use `customFetch` for main `wasm` file loading
-          -e 's/getObject(arg0).fetch(/customFetch(/' \ # Use `customFetch` for assets loading
+          -e 's/function init(input) {/function init(customFetch, input) { customFetch = customFetch || fetch;/' \
+          -e 's/input = fetch(/input = customFetch(/' \
+          -e 's/getObject(arg0).fetch(/customFetch(/' \
           ../../content/examples/$category_path/$example/$example.js
 
         echo "+++

--- a/static/tools.js
+++ b/static/tools.js
@@ -1,0 +1,34 @@
+import { ReadableStream as PolyfillReadableStream, TransformStream as PolyfillTransformStream } from '/web-streams.es6.mjs';
+import { createReadableStreamWrapper } from '/web-streams-adapter.mjs';
+
+// `progressiveFetch` is a wrapper over `window.fetch`. It allows you to insert middle-ware that is
+// polled as the fetch completes. See bevy-website/issues/338 for details.
+async function progressiveFetch(resource, callbacks={}) {
+  const toPolyfillReadable = createReadableStreamWrapper(PolyfillReadableStream);
+  const toNativeReadable = createReadableStreamWrapper(window.ReadableStream);
+
+  const cb = Object.assign({
+    start: (length) => {},
+    update: (loaded, length) => {},
+    finish: (length) => {},
+  }, callbacks);
+  let response = await fetch(resource);
+  const lengthBytes = response.headers.get('content-length');
+  let loadedBytes = 0;
+  const transform = new PolyfillTransformStream({
+    start() {
+      cb.start(lengthBytes);
+    },
+    transform(chunk, controller) {
+      loadedBytes += chunk.byteLength;
+      cb.update(loadedBytes, lengthBytes);
+      controller.enqueue(chunk);
+    },
+    flush() {
+      cb.finish(lengthBytes);
+    },
+  });
+  return new Response(toNativeReadable(toPolyfillReadable(response.body).pipeThrough(transform)), response);
+}
+
+export { progressiveFetch };

--- a/templates/example.html
+++ b/templates/example.html
@@ -25,79 +25,45 @@
     </div>
 </div>
 <script type="module">
-    // Hi curious user!
+    import init from './{{ page.title }}.js';
+    {# // Hi curious user!
     // This approach to add loading feedback on web is a big HACK. Please review `generate_wasm_examples.sh`
     // to see the patches we're applying to the JS file to accept a custom `fetch`. This is a temporary
     // workaround until Bevy has an in-engine mode for showing loading feeback. See:
-    // https://github.com/bevyengine/bevy-website/pull/355
-    // https://github.com/bevyengine/bevy-website/issues/338
-    // https://github.com/bevyengine/bevy-website/issues/236
-    import { ReadableStream as PolyfillReadableStream, TransformStream as PolyfillTransformStream } from '/web-streams.es6.mjs';
-    import { createReadableStreamWrapper } from '/web-streams-adapter.mjs';
-    import init from './{{ page.title }}.js';
+    // https://github.com/bevyengine/bevy-website/pull/355 #}
+    import { progressiveFetch } from '/tools.js';
 
-    // Streams API converters (from/to polyfill)
-    const toPolyfillReadable = createReadableStreamWrapper(PolyfillReadableStream);
-    const toNativeReadable = createReadableStreamWrapper(window.ReadableStream);
-
-    // Elements
     const canvasEl = document.getElementById('bevy');
     const progressStatusEl = document.querySelector('[data-progress-status]');
     let hideProgressTimeoutId;
-
-    // Custom fetch that tracks assets loading progress
-    async function trackLoadingProgressFetch(resource) {
-        const response = await fetch(resource);
-        const lengthBytes = response.headers.get('content-length');
-        let loadedBytes = 0;
-
+    async function loadingBarFetch(resource) {
         // Create new progress bar
         const trackEl = document.createElement('div');
         trackEl.classList.add('example__progress-track');
-
         const progressBarEl = document.createElement('div');
         progressBarEl.classList.add('example__progress-bar');
-
         // Attach progress bar
         trackEl.appendChild(progressBarEl);
         progressStatusEl.appendChild(trackEl);
 
-        // Pipe download through a `TransformStream`
-        const transform = new PolyfillTransformStream({
-            start() {
+        return progressiveFetch(resource, {
+            start: (_) => {
                 progressStatusEl.style.display = 'block';
-
                 if (hideProgressTimeoutId) {
                     clearTimeout(hideProgressTimeoutId);
                 }
             },
-            transform(chunk, controller) {
-                loadedBytes += chunk.byteLength;
-
-                // Update progress bar
-                const percent = loadedBytes / lengthBytes;
-                progressBarEl.style.width = (percent * 100) + '%';
-
-                // Simply pass through the data without touching it.
-                controller.enqueue(chunk);
+            update: (loaded, total) => {
+                progressBarEl.style.width = (100 * loaded/total) + '%';
             },
-            flush() {
-                // Download done, hide progress status element
+            finish: (_) => {
                 hideProgressTimeoutId = setTimeout(() => {
                     progressStatusEl.style.display = 'none';
                 }, 50);
-            },
-        });
+            }
+        })
+    }
 
-        // Give the caller a new version of the Response where we pass its
-        // ReadableStream through the TransformStream.
-        //
-        // Convert to `toPolyfillReadable` to be able to use `pipeThrough` and then
-        // back to `toNativeReadable` (`ReadableStream`) so that everything keeps working
-        return new Response(toNativeReadable(toPolyfillReadable(response.body).pipeThrough(transform)), response);
-    };
-
-    // Init wasm example, pass custom `fetch` implementation
-    init(trackLoadingProgressFetch);
+    init(loadingBarFetch);
 </script>
 {% endblock content %}


### PR DESCRIPTION
I see your [point about iterative development](https://github.com/bevyengine/bevy-website/pull/355#issuecomment-1103543751) being a pain if you needed to rerun the `generate_wasm_examples.sh` script every time. I still think that long-term we should try to move in that direction, when we have better tooling or when the design is more settled; needing to pass in the function to init really sucks, but I agree it is probably the best option we have right now.

This is a compromise; I think keeping `progressiveFetch` factored out makes it tidier (hides the polyfill junk), easier to read/reason about, and will allow us to use similar functionality else-where without duplicating code too heavily (This will be good for blog posts/release notes/et c.).

other small changes: 
- had to remove some of your comments in the generate script because they broke the escaped Returns.
- shortened comments in general. If someone wants to know what's going on, one link to your PR should be enough to get them up to speed.
- put template's comment inside Tera/Zola comment syntax so it won't be rendered